### PR TITLE
Replace memset with std::fill

### DIFF
--- a/src/core/runtime/runtime.cpp
+++ b/src/core/runtime/runtime.cpp
@@ -256,8 +256,7 @@ void Runtime::SetLinkCount(size_t num_link) {
   const size_t last_index = GetIndexLinkInfo(0, num_link);
   link_matrix_.resize(last_index);
 
-  memset(&link_matrix_[0], 0,
-         link_matrix_.size() * sizeof(hsa_amd_memory_pool_link_info_t));
+  std::fill(link_matrix_.begin(), link_matrix_.end(), LinkInfo());
 }
 
 void Runtime::RegisterLinkInfo(uint32_t node_id_from, uint32_t node_id_to,


### PR DESCRIPTION
gcc-8.1 on ArchLinux complains about _clearing an object of non-trivial type._

<pre>
[  2%] Building CXX object CMakeFiles/hsa-runtime64.dir/core/runtime/runtime.cpp.o
/usr/bin/c++  -DHAVE_MEMFD_CREATE -DHSA_EXPORT=1 -DHSA_EXPORT_FINALIZER=1 -DHSA_EXPORT_IMAGES=1 -DLITTLEENDIAN_CPU=1 -DROCR_BUILD_ID=1.0.0- -D__linux__ -Dhsa_runtime64_EXPORTS -I/opt/rocm/libhsakmt/include/libhsakmt -I/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src -I/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/inc -I/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/inc -I/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/libamdhsacode  -Wall -std=c++11  -fpic -Wl,--unresolved-symbols=ignore-in-shared-libs -fno-strict-aliasing -m64  -msse -msse2 -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -fPIC   -D __STDC_LIMIT_MACROS -D __STDC_CONSTANT_MACROS -D __STDC_FORMAT_MACROS -D HSA_DEPRECATED= -o CMakeFiles/hsa-runtime64.dir/core/runtime/runtime.cpp.o -c /home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/runtime/runtime.cpp
/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/runtime/runtime.cpp: In member function 'void core::Runtime::SetLinkCount(size_t)':
/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/runtime/runtime.cpp:260:71: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type '__gnu_cxx::__alloc_traits<std::allocator<core::Runtime::LinkInfo>, core::Runtime::LinkInfo>::value_type' {aka 'struct core::Runtime::LinkInfo'}; use assignment or value-initialization instead [-Werror=class-memaccess]
          link_matrix_.size() * sizeof(hsa_amd_memory_pool_link_info_t));
                                                                       ^
In file included from /home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/runtime/runtime.cpp:43:
/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/src/core/inc/runtime.h:96:10: note: '__gnu_cxx::__alloc_traits<std::allocator<core::Runtime::LinkInfo>, core::Runtime::LinkInfo>::value_type' {aka 'struct core::Runtime::LinkInfo'} declared here
   struct LinkInfo {
          ^~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/hsa-runtime64.dir/build.make:352: CMakeFiles/hsa-runtime64.dir/core/runtime/runtime.cpp.o] Error 1
make[2]: Leaving directory '/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/build'
make[1]: *** [CMakeFiles/Makefile2:71: CMakeFiles/hsa-runtime64.dir/all] Error 2
make[1]: Leaving directory '/home/oleid/packages/hsa-rocr/src/ROCR-Runtime/build'
make: *** [Makefile:155: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
</pre>

This patch makes the code more c++-ish.