### PR TITLE
Fix missing override qualifier in {CPU,GPU}Agent::HiveId()

### DIFF
--- a/src/core/inc/amd_cpu_agent.h
+++ b/src/core/inc/amd_cpu_agent.h
@@ -107,7 +107,7 @@ class CpuAgent : public core::Agent {
   __forceinline size_t num_cache() const { return cache_props_.size(); }
 
   // @brief Returns Hive ID
-  __forceinline uint64_t HiveId() const { return  properties_.HiveID; }
+  __forceinline uint64_t HiveId() const override { return  properties_.HiveID; }
 
   // @brief Returns data cache property.
   //

--- a/src/core/inc/amd_gpu_agent.h
+++ b/src/core/inc/amd_gpu_agent.h
@@ -300,7 +300,7 @@ class GpuAgent : public GpuAgentInt {
   // Getter & setters.
 
   // @brief Returns Hive ID
-  __forceinline uint64_t HiveId() const { return  properties_.HiveID; }
+  __forceinline uint64_t HiveId() const override { return  properties_.HiveID; }
 
   // @brief Returns node property.
   __forceinline const HsaNodeProperties& properties() const {


### PR DESCRIPTION
Compilation fails otherwise with the AOMP build script.