### PR TITLE
Fix hsa_amd_agents_allow_access documentation

### DIFF
--- a/src/inc/hsa_ext_amd.h
+++ b/src/inc/hsa_ext_amd.h
@@ -1167,8 +1167,7 @@ hsa_status_t HSA_API hsa_amd_agent_memory_pool_get_info(
  * ignored.
  *
  * @param[in] flags A list of bit-field that is used to specify access
- * information in a per-agent basis. The size of this list must match that of @p
- * agents. Must be NULL.
+ * information in a per-agent basis. This is currently reserved and must be NULL.
  *
  * @param[in] ptr A buffer previously allocated using ::hsa_amd_memory_pool_allocate.
  *
@@ -1178,8 +1177,8 @@ hsa_status_t HSA_API hsa_amd_agent_memory_pool_get_info(
  * initialized.
  *
  * @retval ::HSA_STATUS_ERROR_INVALID_ARGUMENT @p num_agents is 0, or @p agents
- * is NULL, @p flags is NULL, or attempting to enable access to agent(s) because
- * @p ptr is allocated from an inaccessible pool.
+ * is NULL, @p flags is not NULL, or attempting to enable access to agent(s)
+ * because @p ptr is allocated from an inaccessible pool.
  *
  */
 hsa_status_t HSA_API


### PR DESCRIPTION
I came across this when instrumenting some tracing code for ROCm programs.  The documentation for `hsa_amd_agents_allow_access` says that that an `HSA_STATUS_ERROR_INVALID_ARGUMENT` is returned when the `flags` argument is `NULL`, when the opposite behavior is actually the case.

The earlier description of the `flags` argument contains a similar contradiction (stating the argument must be `NULL` and match the size of the `agents` list), so I updated this comment, too.