### PR TITLE
Drop hsa prefix from include directories so users can #include <hsa/*>

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 target_include_directories( ${CORE_RUNTIME_TARGET}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-  $<INSTALL_INTERFACE:include/hsa>
+  $<INSTALL_INTERFACE:include>
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/libamdhsacode )


### PR DESCRIPTION
It should really be preferred to use

```
#include <hsa/hsa.h>
```

and it seems downstream packages such as HIP are simply not using the `hsa-runtime64::hsa-runtime64` target because it does a poor job at providing the include paths.
